### PR TITLE
CASMCMS-9199: Added support for Python 3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.0] - 2024-11-12
+
+### Added
+
+- CASMCMS-9199: Added support for Python 3.6
+
 ## [2.5.0] - 2024-10-21
 
 ### Changed
@@ -526,6 +532,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Change default reviewers to CMS-core-product-support
 
-[Unreleased]: https://github.com/Cray-HPE/cray-product-catalog-core/compare/v2.5.0...HEAD
+[Unreleased]: https://github.com/Cray-HPE/cray-product-catalog-core/compare/v2.6.0...HEAD
+
+[2.6.0]: https://github.com/Cray-HPE/cray-product-catalog-core/compare/v2.5.0...v2.6.0
 
 [2.5.0]: https://github.com/Cray-HPE/cray-product-catalog-core/compare/5f4a2f8309e954807d7acc6e165308c2a0cd56ba...v2.5.0

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -90,7 +90,26 @@ pipeline {
             steps {
                 sh "make pymod_prepare"
                 sh "make pymod_build"
-                sh "make pymod_test"
+            }
+        }
+
+        stage('Python Test'){
+            matrix {
+                axes {
+                    axis {
+                        name 'PY_VERSION'
+                        values '3.6', '3.9', '3.10', '3.11', '3.12'
+                    }
+                    
+                }
+                agent {
+                    docker {
+                        args '-v /home/jenkins/.ssh:/home/jenkins/.ssh'
+                        reuseNode true
+                        image "${pyImage}:${PY_VERSION}"
+                    }
+                }
+                stages { stage('Pylint') { steps { sh "make -B pymod_test" } } }
             }
         }
 

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@
 # cms-meta-tools repo to ./cms_meta_tools
 
 NAME ?= cray-product-catalog
+PY_VERSION ?= 3.6
+VENV_DIR ?= pylint$(PY_VERSION)
+VENV_PY ?= $(VENV_DIR)/bin/python
 
 all: runbuildprep lint pymod
 pymod: pymod_prepare pymod_build pymod_test
@@ -43,11 +46,13 @@ pymod_build:
 		python3 setup.py sdist bdist_wheel
 
 pymod_test:
-		pip3 install --user -r requirements.txt
-		pip3 install --user -r requirements-test.txt
-		mkdir -p pymod_test
-		python3 setup.py install --user
-		python3 -m unittest discover tests
-		python3 -m pycodestyle --config=.pycodestyle cray_product_catalog tests
+		python3 --version
+		python3 -m venv --system-site-packages $(VENV_DIR)
+		$(VENV_PY) --version
+		$(VENV_PY) -m pip install --upgrade pip build setuptools wheel -c constraints.txt
+		$(VENV_PY) -m pip install dist/cray_product_catalog*.whl -r requirements.txt
+		$(VENV_PY) -m pip install -r requirements-test.txt
+		$(VENV_PY) -m unittest discover tests
+		$(VENV_PY) -m pycodestyle --config=.pycodestyle cray_product_catalog tests
 		# Run pylint, but only fail the build if the code scores lower than 8.0
-		python3 -m pylint --fail-under=8.0 --rcfile=.pylintrc cray_product_catalog tests
+		$(VENV_PY) -m pylint --fail-under=8.0 --rcfile=.pylintrc cray_product_catalog tests

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,24 +1,2 @@
-attrs>=23.1,<23.2
-cachetools>=5.3.3,<5.4
-certifi==2023.5.7
-charset-normalizer>=3.2.0,<3.3
-google-auth>=2.22,<2.23
-idna>=3.4,<3.5
-jsonschema>=4.18.6,<4.19
 # CSM 1.6 moved to Kubernetes 1.24, so use client v24.x to ensure compatability
 kubernetes>=24.2,<24.3
-oauthlib>=3.2.2,<3.3
-pip>=23.2.1,<23.3
-pyasn1>=0.5.1,<0.6
-pyasn1-modules>=0.3,<0.4
-pyrsistent>=0.19.3,<0.20
-python-dateutil>=2.8.2,<2.9
-PyYAML>=6.0.1,<6.1
-requests>=2.31,<2.32
-requests-oauthlib>=1.3.1,<1.4
-rsa>=4.9,<4.10
-setuptools>=68.0,<68.1
-six>=1.16,<1.17
-urllib3>=1.26.19,<1.27
-websocket-client>=1.6.4,<1.7
-wheel>=0.40,<0.41

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         'cray_product_catalog.schema': ['schema.yaml']
     },
     install_requires=install_requires,
-    python_requires='>=3.9, <4',
+    python_requires='>=3.6, <4',
     include_package_data=True,
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Just a packaging change to advertise support for Python 3.6.
Also made the build-time testing more thorough, to validate the package against the supported Python versions.