### PR TITLE
CRAYSAT-1944: Improve performance of ProductCatalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.8.0] - 2025-07-15
+
+### Added
+- Added `shallow` boolean argument to the `ProductCatalog` constructor. If set
+  to `True`, it only loads product catalog data from the top-level ConfigMap,
+  skipping over product-specific ConfigMaps containing `component_versions`
+  data. This improves performance if that data is not needed.
+
+### Changed
+- Improved performance of loading and validating product catalog data when
+  creating an instance of `ProductCatalog`.
+
+### Deprecated
+- Deprecated top-level functions `load_cm_data` and `load_config_map_data`.
+  These were primarily for use by the `ProductCatalog` constructor, and external
+  users of the library should not have been using them. They have been replaced
+  by internal methods in `ProductCatalog` that are called in the constructor.
 
 ## [2.7.0] - 2025-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.8.0] - 2025-07-15
 
 ### Added
-- Added `shallow` boolean argument to the `ProductCatalog` constructor. If set
+- CRAYSAT-1944: Added `shallow` boolean argument to the `ProductCatalog` constructor. If set
   to `True`, it only loads product catalog data from the top-level ConfigMap,
   skipping over product-specific ConfigMaps containing `component_versions`
   data. This improves performance if that data is not needed.
 
 ### Changed
-- Improved performance of loading and validating product catalog data when
+- CRAYSAT-1944: Improved performance of loading and validating product catalog data when
   creating an instance of `ProductCatalog`.
 
 ### Deprecated
-- Deprecated top-level functions `load_cm_data` and `load_config_map_data`.
+- CRAYSAT-1944: Deprecated top-level functions `load_cm_data` and `load_config_map_data`.
   These were primarily for use by the `ProductCatalog` constructor, and external
   users of the library should not have been using them. They have been replaced
   by internal methods in `ProductCatalog` that are called in the constructor.

--- a/cray_product_catalog/util/__init__.py
+++ b/cray_product_catalog/util/__init__.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023, 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -27,3 +27,4 @@ Defines a utility function for loading the Kubernetes configuration.
 
 # import load_k8s here so that load_k8s can be imported from cray_product_catalog.util
 from cray_product_catalog.util.k8s import load_k8s
+from cray_product_catalog.util.cached_property import cached_property


### PR DESCRIPTION

## Summary and Scope

Improve the performance of loading the data from the product catalog Kubernetes ConfigMaps during construction of `ProductCatalog` as follows:

* Only load and validate the product catalog schema file against the JSON Schema metaschema once and re-use the validator across all instances of InstalledProductVersion.
* Add a `shallow` boolean optional argument to `ProductCatalog` that allows it to only load product catalog data from the main `cray-product-catalog` ConfigMap if that's all that the user of the library needs.
* Cache the value of the `is_valid` property on the `InstalledProductVersion`. This only needs to be computed once. It is accessed twice in the `ProductCatalog` constructor.

Fix existing unit tests to work with the refactored code. The tests now mock only the Kubernetes API calls, so we are testing all the code called by the constructor of the `ProductCatalog`. Add tests for the `shallow` parameter that was added to `ProductCatalog`. Also add tests for `get_product` when the requested product does not exist in the product catalog.

## Issues and Related PRs

* Resolves CRAYSAT-1944

## Testing

### Tested on:

* rocket

### Test description:

Unit tests pass.

Included the new version in a build of the `cray-sat` container and tested on rocket. (In progress)

## Risks and Mitigations

There is some risk because this refactors a lot of the code in the `query` module. However, the main user of this code is `sat`, and it is being tested well via automated SAT functional tests.

Unit tests are also thorough for the `query` module here.

It is also optional for users of this library to pull in this new version.

## Pull Request Checklist

- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Is a new version being released? Update https://github.com/Cray-HPE/cray-product-catalog/wiki/CSM-Compatibility-Matrix
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
